### PR TITLE
Sound Config Fixes and Changes

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -687,7 +687,7 @@
     </plugins>
   </reporting>
   <properties>
-    <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>11</java.version>
   </properties>
 </project>

--- a/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
+++ b/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
@@ -1,6 +1,5 @@
 package com.ranull.graves.listener;
 
-
 import com.ranull.graves.Graves;
 import com.ranull.graves.data.BlockData;
 import com.ranull.graves.event.*;

--- a/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
+++ b/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
@@ -1,5 +1,6 @@
 package com.ranull.graves.listener;
 
+
 import com.ranull.graves.Graves;
 import com.ranull.graves.data.BlockData;
 import com.ranull.graves.event.*;
@@ -745,9 +746,9 @@ public class EntityDeathListener implements Listener {
             } else {
                 plugin.getIntegrationManager().getNoteBlockAPI().playSongForAllPlayers(nbsSound);
             }
-        } else {
-            player.playSound(player.getLocation(), plugin.getVersionManager().getSoundFromVersion("BLOCK_BELL_USE"), 1.0f, 0.93f);
-        }
+            } else { 
+                plugin.getEntityManager().playPlayerSound("sound.grave-create", player, grave);
+            }
 
         if (plugin.getIntegrationManager().hasMultiPaper()) {
             plugin.getIntegrationManager().getMultiPaper().notifyGraveCreation(grave);

--- a/src/main/java/com/ranull/graves/manager/EntityManager.java
+++ b/src/main/java/com/ranull/graves/manager/EntityManager.java
@@ -450,7 +450,7 @@ public final class EntityManager extends EntityDataManager {
      */
     public void playWorldSound(String string, Location location, Grave grave) {
         playWorldSound(string, location, grave != null ? grave.getOwnerType() : null, grave != null
-                ? grave.getPermissionList() : null,  1, 1);
+                ? grave.getPermissionList() : null, 1, 1);
     }
 
     /**

--- a/src/main/java/com/ranull/graves/manager/EntityManager.java
+++ b/src/main/java/com/ranull/graves/manager/EntityManager.java
@@ -450,7 +450,7 @@ public final class EntityManager extends EntityDataManager {
      */
     public void playWorldSound(String string, Location location, Grave grave) {
         playWorldSound(string, location, grave != null ? grave.getOwnerType() : null, grave != null
-                ? grave.getPermissionList() : null, 1, 1);
+                ? grave.getPermissionList() : null,  1, 1);
     }
 
     /**

--- a/src/main/java/com/ranull/graves/manager/VersionManager.java
+++ b/src/main/java/com/ranull/graves/manager/VersionManager.java
@@ -611,25 +611,6 @@ public final class VersionManager {
         return toReturn;
     }
 
-    public Sound getSoundFromVersion(String sound) {
-        Sound toReturn = null;
-        switch (sound) {
-            case "BLOCK_BELL_USE":
-                try {
-                    toReturn = CompatibilitySoundEnum.valueOf("BLOCK_BELL_USE");
-                } catch (NullPointerException | IllegalArgumentException e) {
-                    toReturn = CompatibilitySoundEnum.valueOf("ENTITY_ZOMBIE_AMBIENT");
-                }
-                break;
-                // Add other cases for different sounds here
-        }
-        if (toReturn == null) {
-            throw new IllegalArgumentException("Sound can't be null. This is a bug.");
-        }
-
-        return toReturn;
-    }
-
     public PotionEffectType getPotionEffectTypeFromVersion(String potionEffect) {
         PotionEffectType toReturn = null;
         switch (potionEffect) {

--- a/src/main/java/dev/cwhead/GravesX/GravesXAPI.java
+++ b/src/main/java/dev/cwhead/GravesX/GravesXAPI.java
@@ -345,8 +345,8 @@ public class GravesXAPI {
                         } else {
                             plugin.getIntegrationManager().getNoteBlockAPI().playSongForAllPlayers(nbsSound);
                         }
-                    } else {
-                        player.playSound(player.getLocation(), plugin.getVersionManager().getSoundFromVersion("BLOCK_BELL_USE"), 1.0f, 0.93f);
+                    } else { 
+                        plugin.getEntityManager().playPlayerSound("sound.grave-create", player, grave);
                     }
                 }
 

--- a/src/main/resources/config/grave.yml
+++ b/src/main/resources/config/grave.yml
@@ -617,14 +617,16 @@ settings:
       #########
       # Sound effects for various grave interactions.
       sound:
-        open: BLOCK_FENCE_GATE_OPEN
-        close: BLOCK_FENCE_GATE_CLOSE
-        loot: ITEM_FIRECHARGE_USE
-        teleport: ENTITY_ENDERMAN_TELEPORT
-        menu-open: UI_BUTTON_CLICK
-        protection: BLOCK_CHEST_LOCKED
-        protection-change: UI_BUTTON_CLICK
-
+        open: "BLOCK_FENCE_GATE_OPEN"
+        close: "BLOCK_FENCE_GATE_CLOSE"
+        teleport: "ENTITY_ENDERMAN_TELEPORT"
+        menu-open: "UI_BUTTON_CLICK"
+        protection: "BLOCK_CHEST_LOCKED"
+        protection-change: "UI_BUTTON_CLICK"
+        grave-create: ""
+        
+        # Sounds for grave-create previously included BLOCK_BELL_USE and ENTITY_ZOMBIE_AMBIENT.
+        
       ##########
       # Effect #
       ##########


### PR DESCRIPTION
- Added "" for the string sound values in graves.yml by default in order to make sure that people know they can make the sound value empty so that no sound players.

- Added a new sound config, sound.grave-create which replaces the weird getSoundFromVersion function. This is by default empty, but added a comment in the config with the previous options. If you think it should have a sound by default, a good one is BLOCK_ANVIL_USE although it is still really loud and annoying. 

- Removed the getSoundFromVersion function as its not needed anymore.

- Removed the loot part of the sound config as it goes unused and it seems like it was replaced by ranull ages ago. 

