### PR TITLE
Fix grave.explode setting being ignored

### DIFF
--- a/src/main/java/dev/cwhead/GravesX/listener/BlockEntityExplodeListener.java
+++ b/src/main/java/dev/cwhead/GravesX/listener/BlockEntityExplodeListener.java
@@ -110,14 +110,10 @@ public class BlockEntityExplodeListener implements Listener {
             Location graveHeadLocation = grave.getLocationDeath();
 
             // If the exploding block is exactly the grave head block, protect it.
-            if (graveHeadLocation != null && graveHeadLocation.equals(block.getLocation())) {
+            if (graveHeadLocation != null && graveHeadLocation.equals(block.getLocation()) && !shouldExplode(grave)) {
                 plugin.debugMessage("[Explode Debug] " + source + ": protecting grave head block for grave "
                         + grave.getUUID(), 2);
                 iterator.remove();
-                continue;
-            }
-
-            if (!shouldExplode(grave)) {
                 continue;
             }
 


### PR DESCRIPTION
This commit makes it so that when the `grave.explode` setting is enabled, graves will be exploded and drop their items when caught in the explosion of a block or entity.