### PR TITLE
Add BagOfGold physical-money split integration and harden safe-location/shutdown/DB startup behavio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>graves</artifactId>
     <name>GravesX</name>
     <description>Full featured lightweight death chest plugin.</description>
-    <version>4.9.11.1-JL.1</version>
+    <version>4.9.11.1</version>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>graves</artifactId>
     <name>GravesX</name>
     <description>Full featured lightweight death chest plugin.</description>
-    <version>4.9.11.1</version>
+    <version>4.9.11.1-JL.1</version>
 
     <developers>
         <developer>

--- a/src/main/java/com/ranull/graves/Graves.java
+++ b/src/main/java/com/ranull/graves/Graves.java
@@ -80,6 +80,8 @@ public class Graves extends JavaPlugin {
     private TextDisplayManager textDisplayManager;
 
     private final AtomicBoolean reloading = new AtomicBoolean(false);
+    private final AtomicBoolean normalDisable = new AtomicBoolean(false);
+    private final AtomicBoolean shutdownTasksRan = new AtomicBoolean(false);
 
     @Override
     public void onLoad() {
@@ -263,6 +265,7 @@ public class Graves extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        normalDisable.set(true);
         if (moduleManager != null) {
             getLogger().info("[Modules] Disabling modules...");
             moduleManager.disableAll();
@@ -275,9 +278,13 @@ public class Graves extends JavaPlugin {
         getLogger().info("Registering Soft Crash Handler...");
         try {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // JVM shutdown hooks run on both crash and graceful stop.
+                // If Bukkit already triggered onDisable, skip duplicate shutdown work.
+                if (normalDisable.get() || shutdownTasksRan.get()) {
+                    return;
+                }
                 getLogger().severe("GravesX detected server went into a crashed state...");
                 runShutdownTasks();
-                getServer().getPluginManager().disablePlugin(this);
             }));
             getLogger().info("Registered Soft Crash Handler. Server will handle crashes in a separate thread. This does not work on hard crashes.");
         } catch (Exception e) {
@@ -286,6 +293,11 @@ public class Graves extends JavaPlugin {
     }
 
     private void runShutdownTasks() {
+        if (!shutdownTasksRan.compareAndSet(false, true)) {
+            debugMessage("Skipping duplicate shutdown task execution.", 1);
+            return;
+        }
+
         getLogger().info("Saving Grave inventories before shutting down...");
         for (Grave grave : getCacheManager().getGraveMap().values()) {
             try {
@@ -303,8 +315,10 @@ public class Graves extends JavaPlugin {
         getLogger().info("Shutting Down GravesX...");
         getLogger().info("Unloading and Shutting Down DataManager...");
         try {
-            dataManager.closeConnection();
-            getLogger().info("Unloaded DataManager Successfully.");
+            if (dataManager != null) {
+                dataManager.closeConnection();
+                getLogger().info("Unloaded DataManager Successfully.");
+            }
         } catch (Exception e) {
             getLogger().severe("Failed to unload DataManager and shut down Database.");
             logStackTrace(e);
@@ -312,8 +326,10 @@ public class Graves extends JavaPlugin {
 
         getLogger().info("Unloading GraveManager...");
         try {
-            graveManager.unload();
-            getLogger().info("Unloaded GraveManager Successfully.");
+            if (graveManager != null) {
+                graveManager.unload();
+                getLogger().info("Unloaded GraveManager Successfully.");
+            }
         } catch (Exception e) {
             getLogger().severe("Failed to unload GraveManager.");
             logStackTrace(e);
@@ -321,9 +337,11 @@ public class Graves extends JavaPlugin {
 
         getLogger().info("Unloading IntegrationManager...");
         try {
-            integrationManager.unload();
-            integrationManager.unloadNoReload();
-            getLogger().info("Unloaded IntegrationManager Successfully.");
+            if (integrationManager != null) {
+                integrationManager.unload();
+                integrationManager.unloadNoReload();
+                getLogger().info("Unloaded IntegrationManager Successfully.");
+            }
         } catch (Exception e) {
             getLogger().severe("Failed to unload IntegrationManager.");
             logStackTrace(e);

--- a/src/main/java/com/ranull/graves/integration/BagOfGoldPhysicalMoneyIntegration.java
+++ b/src/main/java/com/ranull/graves/integration/BagOfGoldPhysicalMoneyIntegration.java
@@ -1,0 +1,355 @@
+package com.ranull.graves.integration;
+
+import com.ranull.graves.Graves;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Integrates GravesX with BagOfGold's physical-money items.
+ *
+ * <p>Only item stacks marked as real BagOfGold/CustomItemsLib rewards are processed.
+ * This integration never touches digital balances (Vault/DB).</p>
+ */
+public final class BagOfGoldPhysicalMoneyIntegration {
+    private static final String BAGOFGOLD_PLUGIN = "BagOfGold";
+    private static final double EPSILON = 1.0E-9D;
+    private static final int FLOOR_SCALE = 5;
+
+    private final Graves plugin;
+    private @Nullable RewardReflectionBridge bridge;
+    private boolean warnedMissingPlugin;
+    private boolean warnedReflectionFailure;
+    private boolean loggedHook;
+
+    public BagOfGoldPhysicalMoneyIntegration(@NotNull Graves plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Splits BagOfGold physical money from grave items into ignored items so ignored items
+     * are dropped on the ground by GravesX.
+     *
+     * @param livingEntity   dead entity
+     * @param permissionList resolved GravesX permissions for this entity (nullable)
+     * @param graveItems     items currently intended for grave storage
+     * @param ignoredItems   items that should drop outside the grave
+     * @param preserveSlots  true for EXACT storage mode (keep list indices stable)
+     */
+    public void splitPhysicalMoney(
+            @NotNull LivingEntity livingEntity,
+            @Nullable List<String> permissionList,
+            @NotNull List<ItemStack> graveItems,
+            @NotNull List<ItemStack> ignoredItems,
+            boolean preserveSlots
+    ) {
+        if (!(livingEntity instanceof Player)) return;
+        if (graveItems.isEmpty()) return;
+        if (!isIntegrationEnabled()) return;
+
+        ConfigurationSection section = plugin.getConfigManager()
+                .getConfigSection("physical-money.bagofgold.enabled", livingEntity, permissionList);
+        if (section == null) return;
+
+        if (!section.getBoolean("physical-money.bagofgold.enabled", true)) return;
+        if (!isAllowedByDeathScope(livingEntity, section.getString("physical-money.bagofgold.apply-on", "pvp_and_pve"))) {
+            return;
+        }
+
+        RewardReflectionBridge resolved = resolveBridge();
+        if (resolved == null) return;
+
+        double dropPercent = getDropPercent(section);
+        if (dropPercent <= 0.0D) return;
+
+        double totalMoney = computeTotalPhysicalMoney(graveItems, resolved);
+        if (totalMoney <= 0.0D) return;
+
+        double targetDropValue = floorToScale(totalMoney * (dropPercent / 100.0D), FLOOR_SCALE);
+        if (targetDropValue <= 0.0D) return;
+
+        double moved = 0.0D;
+        for (int i = 0; i < graveItems.size() && moved + EPSILON < targetDropValue; i++) {
+            ItemStack stack = graveItems.get(i);
+            if (stack == null || stack.getType() == Material.AIR || stack.getAmount() <= 0) continue;
+
+            double unitValue = resolved.getUnitMoney(stack);
+            if (unitValue <= 0.0D) continue;
+
+            double remainingTarget = (targetDropValue - moved);
+            if (remainingTarget > EPSILON && stack.getAmount() == 1) {
+                int maxTakeForSingle = (int) Math.floor((remainingTarget + EPSILON) / unitValue);
+                if (maxTakeForSingle <= 0) {
+                    double dropValue = floorToScale(Math.min(remainingTarget, unitValue), FLOOR_SCALE);
+                    if (dropValue > EPSILON && dropValue + EPSILON < unitValue) {
+                        ItemStack droppedPartial = resolved.rewriteMoney(stack, dropValue);
+                        ItemStack keptPartial = resolved.rewriteMoney(stack, floorToScale(unitValue - dropValue, FLOOR_SCALE));
+                        if (droppedPartial != null && keptPartial != null) {
+                            ignoredItems.add(droppedPartial);
+                            graveItems.set(i, keptPartial);
+                            moved += dropValue;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            int maxTake = (int) Math.floor(((targetDropValue - moved) + EPSILON) / unitValue);
+            if (maxTake <= 0) continue;
+
+            int available = stack.getAmount();
+            int take = Math.min(available, maxTake);
+            if (take <= 0) continue;
+
+            if (take >= available) {
+                ItemStack dropped = stack.clone();
+                ignoredItems.add(dropped);
+                if (preserveSlots) {
+                    graveItems.set(i, null);
+                } else {
+                    graveItems.remove(i);
+                    i--;
+                }
+            } else {
+                ItemStack dropped = stack.clone();
+                dropped.setAmount(take);
+                ignoredItems.add(dropped);
+
+                ItemStack remaining = stack.clone();
+                remaining.setAmount(available - take);
+                graveItems.set(i, remaining);
+            }
+
+            moved += (unitValue * take);
+        }
+
+        boolean forceMinimumDrop = section.getBoolean("physical-money.bagofgold.force-minimum-drop-item", true);
+        if (forceMinimumDrop && targetDropValue > 0.0D && moved <= EPSILON) {
+            moved += forceSingleUnitDrop(graveItems, ignoredItems, preserveSlots, resolved);
+        }
+
+        if (moved > 0.0D) {
+            plugin.debugMessage(
+                    "BagOfGold physical split applied: moved " + floorToScale(moved, FLOOR_SCALE)
+                            + " value to ground drops (" + dropPercent + "% target).",
+                    1
+            );
+        }
+    }
+
+    private boolean isIntegrationEnabled() {
+        FileConfiguration config = plugin.getConfig();
+        if (config == null) return true;
+
+        String path = "settings.integration.bagofgold.enabled";
+        if (config.contains(path) && !config.getBoolean(path, true)) return false;
+
+        return true;
+    }
+
+    private double forceSingleUnitDrop(
+            @NotNull List<ItemStack> graveItems,
+            @NotNull List<ItemStack> ignoredItems,
+            boolean preserveSlots,
+            @NotNull RewardReflectionBridge resolved
+    ) {
+        int bestIndex = -1;
+        double bestUnitValue = Double.MAX_VALUE;
+
+        for (int i = 0; i < graveItems.size(); i++) {
+            ItemStack stack = graveItems.get(i);
+            if (stack == null || stack.getType() == Material.AIR || stack.getAmount() <= 0) continue;
+
+            double unitValue = resolved.getUnitMoney(stack);
+            if (unitValue <= 0.0D) continue;
+
+            if (unitValue < bestUnitValue) {
+                bestUnitValue = unitValue;
+                bestIndex = i;
+            }
+        }
+
+        if (bestIndex < 0) return 0.0D;
+
+        ItemStack stack = graveItems.get(bestIndex);
+        if (stack == null || stack.getType() == Material.AIR || stack.getAmount() <= 0) return 0.0D;
+
+        ItemStack dropped = stack.clone();
+        dropped.setAmount(1);
+        ignoredItems.add(dropped);
+
+        if (stack.getAmount() <= 1) {
+            if (preserveSlots) {
+                graveItems.set(bestIndex, null);
+            } else {
+                graveItems.remove(bestIndex);
+            }
+        } else {
+            ItemStack remaining = stack.clone();
+            remaining.setAmount(stack.getAmount() - 1);
+            graveItems.set(bestIndex, remaining);
+        }
+
+        return bestUnitValue;
+    }
+
+    private boolean isAllowedByDeathScope(@NotNull LivingEntity livingEntity, @Nullable String modeRaw) {
+        String mode = modeRaw == null ? "pvp_and_pve" : modeRaw.trim().toLowerCase();
+        boolean pvp = livingEntity.getKiller() != null;
+
+        return switch (mode) {
+            case "pvp_only" -> pvp;
+            case "pve_only" -> !pvp;
+            default -> true; // pvp_and_pve (or unknown value -> safe default)
+        };
+    }
+
+    private double getDropPercent(@NotNull ConfigurationSection section) {
+        final String dropPath = "physical-money.bagofgold.drop-on-ground-percent";
+        final String keepPath = "physical-money.bagofgold.keep-in-grave-percent";
+
+        double drop = section.contains(dropPath)
+                ? section.getDouble(dropPath, 30.0D)
+                : (100.0D - section.getDouble(keepPath, 70.0D));
+
+        if (!Double.isFinite(drop)) return 0.0D;
+        if (drop < 0.0D) return 0.0D;
+        if (drop > 100.0D) return 100.0D;
+        return drop;
+    }
+
+    private double computeTotalPhysicalMoney(@NotNull List<ItemStack> items, @NotNull RewardReflectionBridge resolved) {
+        double total = 0.0D;
+        for (ItemStack item : items) {
+            if (item == null || item.getType() == Material.AIR || item.getAmount() <= 0) continue;
+            double unit = resolved.getUnitMoney(item);
+            if (unit <= 0.0D) continue;
+            total += unit * item.getAmount();
+        }
+        return floorToScale(total, FLOOR_SCALE);
+    }
+
+    private @Nullable RewardReflectionBridge resolveBridge() {
+        if (bridge != null) return bridge;
+
+        Plugin bag = plugin.getServer().getPluginManager().getPlugin(BAGOFGOLD_PLUGIN);
+        if (bag == null || !bag.isEnabled()) {
+            if (!warnedMissingPlugin) {
+                warnedMissingPlugin = true;
+                plugin.integrationMessage("BagOfGold physical-money split is enabled, but BagOfGold is not loaded. Skipping split.", "warn");
+            }
+            return null;
+        }
+
+        try {
+            bridge = new RewardReflectionBridge();
+            if (!loggedHook) {
+                loggedHook = true;
+                plugin.integrationMessage("Hooked into BagOfGold physical item metadata via CustomItemsLib Reward reflection.");
+            }
+            return bridge;
+        } catch (Throwable throwable) {
+            if (!warnedReflectionFailure) {
+                warnedReflectionFailure = true;
+                plugin.integrationMessage("Failed to initialize BagOfGold physical-money reflection bridge: " + throwable.getMessage(), "warn");
+            }
+            return null;
+        }
+    }
+
+    private static double floorToScale(double value, int scale) {
+        if (!Double.isFinite(value)) return 0.0D;
+        double factor = Math.pow(10, scale);
+        return Math.floor(value * factor) / factor;
+    }
+
+    private static final class RewardReflectionBridge {
+        private final Method rewardIsReward;
+        private final Method rewardGetReward;
+        private final Method rewardIsMoney;
+        private final Method rewardGetMoney;
+        private final Method rewardSetMoney;
+        private final Method rewardSetDisplayAndLore;
+        private final @Nullable Method rewardCheckHash;
+
+        private RewardReflectionBridge() throws ClassNotFoundException, NoSuchMethodException {
+            Class<?> rewardClass = Class.forName("one.lindegaard.CustomItemsLib.rewards.Reward");
+            this.rewardIsReward = rewardClass.getMethod("isReward", ItemStack.class);
+            this.rewardGetReward = rewardClass.getMethod("getReward", ItemStack.class);
+            this.rewardIsMoney = rewardClass.getMethod("isMoney");
+            this.rewardGetMoney = rewardClass.getMethod("getMoney");
+            this.rewardSetMoney = rewardClass.getMethod("setMoney", double.class);
+            this.rewardSetDisplayAndLore = rewardClass.getMethod("setDisplayNameAndHiddenLores", ItemStack.class, rewardClass);
+
+            Method checkHash;
+            try {
+                checkHash = rewardClass.getMethod("checkHash");
+            } catch (NoSuchMethodException ignored) {
+                checkHash = null;
+            }
+            this.rewardCheckHash = checkHash;
+        }
+
+        private double getUnitMoney(@Nullable ItemStack itemStack) {
+            if (itemStack == null || itemStack.getType() == Material.AIR) return 0.0D;
+
+            try {
+                Object isReward = rewardIsReward.invoke(null, itemStack);
+                if (!(isReward instanceof Boolean) || !((Boolean) isReward)) return 0.0D;
+
+                Object rewardObj = rewardGetReward.invoke(null, itemStack);
+                if (rewardObj == null) return 0.0D;
+
+                if (rewardCheckHash != null) {
+                    Object checkHash = rewardCheckHash.invoke(rewardObj);
+                    if (!(checkHash instanceof Boolean) || !((Boolean) checkHash)) return 0.0D;
+                }
+
+                Object isMoney = rewardIsMoney.invoke(rewardObj);
+                if (!(isMoney instanceof Boolean) || !((Boolean) isMoney)) return 0.0D;
+
+                Object money = rewardGetMoney.invoke(rewardObj);
+                if (!(money instanceof Number)) return 0.0D;
+
+                double unitValue = ((Number) money).doubleValue();
+                return (Double.isFinite(unitValue) && unitValue > 0.0D) ? unitValue : 0.0D;
+            } catch (Throwable ignored) {
+                return 0.0D;
+            }
+        }
+
+        private @Nullable ItemStack rewriteMoney(@Nullable ItemStack base, double newMoney) {
+            if (base == null || base.getType() == Material.AIR) return null;
+            if (!Double.isFinite(newMoney) || newMoney <= 0.0D) return null;
+
+            try {
+                Object isReward = rewardIsReward.invoke(null, base);
+                if (!(isReward instanceof Boolean) || !((Boolean) isReward)) return null;
+
+                Object rewardObj = rewardGetReward.invoke(null, base);
+                if (rewardObj == null) return null;
+
+                Object isMoney = rewardIsMoney.invoke(rewardObj);
+                if (!(isMoney instanceof Boolean) || !((Boolean) isMoney)) return null;
+
+                rewardSetMoney.invoke(rewardObj, newMoney);
+
+                ItemStack rewritten = (ItemStack) rewardSetDisplayAndLore.invoke(null, base.clone(), rewardObj);
+                if (rewritten == null || rewritten.getType() == Material.AIR) return null;
+                rewritten.setAmount(1);
+                return rewritten;
+            } catch (Throwable ignored) {
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
+++ b/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
@@ -3,6 +3,7 @@ package com.ranull.graves.listener;
 import com.ranull.graves.Graves;
 import com.ranull.graves.compatibility.CompatibilityInventoryView;
 import com.ranull.graves.data.BlockData;
+import com.ranull.graves.integration.BagOfGoldPhysicalMoneyIntegration;
 import com.ranull.graves.type.Grave;
 import com.ranull.graves.util.ExperienceUtil;
 import com.ranull.graves.util.LocationUtil;
@@ -42,6 +43,7 @@ import java.util.*;
  */
 public class EntityDeathListener implements Listener {
     private final Graves plugin;
+    private final BagOfGoldPhysicalMoneyIntegration bagOfGoldPhysicalMoneyIntegration;
 
     /**
      * Constructs an EntityDeathListener with the specified Graves plugin.
@@ -50,6 +52,7 @@ public class EntityDeathListener implements Listener {
      */
     public EntityDeathListener(Graves plugin) {
         this.plugin = plugin;
+        this.bagOfGoldPhysicalMoneyIntegration = new BagOfGoldPhysicalMoneyIntegration(plugin);
     }
 
     /**
@@ -556,6 +559,14 @@ public class EntityDeathListener implements Listener {
                     }
                 }
 
+                bagOfGoldPhysicalMoneyIntegration.splitPhysicalMoney(
+                        livingEntity,
+                        permissionList,
+                        slots,
+                        ignoredItemStackList,
+                        true
+                );
+
                 return slots;
             }
 
@@ -595,6 +606,14 @@ public class EntityDeathListener implements Listener {
                     dropIt.remove();
                 }
             }
+
+            bagOfGoldPhysicalMoneyIntegration.splitPhysicalMoney(
+                    livingEntity,
+                    permissionList,
+                    graveList,
+                    ignoredItemStackList,
+                    false
+            );
 
             return graveList;
 
@@ -1481,7 +1500,7 @@ public class EntityDeathListener implements Listener {
             if (ignoredItems != null) {
                 for (ItemStack item : ignoredItems) {
                     if (item != null && item.getType() != Material.AIR) {
-                        world.dropItemNaturally(dropLoc, item);
+                        world.dropItemNaturally(dropLoc, item.clone());
                     }
                 }
             }

--- a/src/main/java/com/ranull/graves/listener/PlayerMoveListener.java
+++ b/src/main/java/com/ranull/graves/listener/PlayerMoveListener.java
@@ -6,6 +6,7 @@ import com.ranull.graves.data.ChunkData;
 import com.ranull.graves.integration.MiniMessage;
 import com.ranull.graves.type.Grave;
 import com.ranull.graves.util.LocationUtil;
+import com.ranull.graves.util.MaterialUtil;
 import com.ranull.graves.util.StringUtil;
 import dev.cwhead.GravesX.event.GraveWalkOverEvent;
 import org.bukkit.GameMode;
@@ -106,7 +107,12 @@ public class PlayerMoveListener implements Listener {
      * @return True if the location is safe, false otherwise.
      */
     private boolean isLocationSafe(Location location) {
+        Material feet = location.getBlock().getType();
+        Material head = location.getBlock().getRelative(BlockFace.UP).getType();
+
         return plugin.getLocationManager().isInsideBorder(location)
+                && !MaterialUtil.isWater(feet)
+                && !MaterialUtil.isWater(head)
                 && location.getBlock().getRelative(BlockFace.DOWN).getType().isSolid()
                 && plugin.getLocationManager().isLocationSafePlayer(location);
     }

--- a/src/main/java/com/ranull/graves/manager/DataManager.java
+++ b/src/main/java/com/ranull/graves/manager/DataManager.java
@@ -1134,7 +1134,9 @@ public class DataManager {
         }
 
         addColumnIfNotExists(name, "uuid", "VARCHAR(255) UNIQUE");
-        alterColumnIfExists(name, "uuid", "VARCHAR(255) UNIQUE");
+        // Do not ALTER with UNIQUE on every startup for MySQL/MariaDB, as some engines can
+        // create duplicate unique keys repeatedly and eventually hit key-count limits.
+        alterColumnIfExists(name, "uuid", "VARCHAR(255)");
 
         addColumnIfNotExists(name, "owner_type", "VARCHAR(255)");
         alterColumnIfExists(name, "owner_type", "VARCHAR(255)");

--- a/src/main/java/com/ranull/graves/manager/DataManager.java
+++ b/src/main/java/com/ranull/graves/manager/DataManager.java
@@ -1396,7 +1396,29 @@ public class DataManager {
         };
 
         if (backfillBackend != null) {
-            executeUpdate(backfillBackend, new Object[0]);
+            final String finalName = name;
+            final String finalBackfillBackend = backfillBackend;
+
+            // Run backfill shortly after schema migrations to avoid startup races where
+            // the UPDATE executes before the backend column is actually added.
+            plugin.getSchedulerManager().runTaskLaterAsynchronously(() -> {
+                List<String> columns = getColumnList(finalName);
+                if (!columns.contains("backend")) {
+                    plugin.debugMessage(
+                            "Skipping hologram backend backfill for table '" + finalName + "' because column 'backend' is still missing.",
+                            2
+                    );
+                    return;
+                }
+
+                try {
+                    executeUpdateMainThread(finalBackfillBackend, new Object[0]);
+                } catch (SQLException exception) {
+                    plugin.getLogger().severe("Error executing hologram backend backfill");
+                    plugin.getLogger().severe("Failed SQL statement: " + finalBackfillBackend);
+                    plugin.logStackTrace(exception);
+                }
+            }, 40L);
         }
     }
 

--- a/src/main/java/com/ranull/graves/manager/GraveManager.java
+++ b/src/main/java/com/ranull/graves/manager/GraveManager.java
@@ -31,12 +31,14 @@ import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
+import java.lang.reflect.Method;
 
 /**
  * Manages the operations and lifecycle of graves within the Graves plugin.
@@ -2457,6 +2459,7 @@ public class GraveManager {
                 InventoryUtil.equipArmor(grave.getInventory(), player);InventoryUtil.equipItems(grave.getInventory(), player);
             }
 
+            syncBagOfGoldBalanceAfterAutoloot(player);
             player.updateInventory();
 
             plugin.getDataManager().updateGrave(grave, "inventory", InventoryUtil.inventoryToString(grave.getInventory()));
@@ -2480,6 +2483,33 @@ public class GraveManager {
                 plugin.getEntityManager().playWorldSound("sound.open", location, grave);
             }
         });
+    }
+
+    /**
+     * Keeps BagOfGold balance consistent after GravesX programmatically moves items from a grave
+     * to the player's inventory (auto-loot path). Inventory API moves do not always fire the same
+     * click/pickup handlers BagOfGold uses for balance sync, so we trigger BagOfGold's own
+     * reconciliation method once after auto-loot.
+     */
+    private void syncBagOfGoldBalanceAfterAutoloot(@NotNull Player player) {
+        Plugin bagOfGold = plugin.getServer().getPluginManager().getPlugin("BagOfGold");
+        if (bagOfGold == null || !bagOfGold.isEnabled()) return;
+
+        try {
+            Method getInstance = bagOfGold.getClass().getMethod("getInstance");
+            Object instance = getInstance.invoke(null);
+            if (instance == null) return;
+
+            Method getRewardManager = instance.getClass().getMethod("getRewardManager");
+            Object rewardManager = getRewardManager.invoke(instance);
+            if (rewardManager == null) return;
+
+            Method adjustToInventory = rewardManager.getClass()
+                    .getMethod("adjustPlayerBalanceToAmounOfMoneyInInventory", Player.class);
+            adjustToInventory.invoke(rewardManager, player);
+        } catch (Throwable throwable) {
+            plugin.debugMessage("Failed to sync BagOfGold balance after grave auto-loot: " + throwable.getMessage(), 1);
+        }
     }
 
     /**

--- a/src/main/java/com/ranull/graves/manager/IntegrationManager.java
+++ b/src/main/java/com/ranull/graves/manager/IntegrationManager.java
@@ -311,7 +311,13 @@ public class IntegrationManager {
         }
 
         if (placeholderAPI != null) {
-            placeholderAPI.unregister();
+            try {
+                placeholderAPI.unregister();
+            } catch (Throwable throwable) {
+                plugin.getLogger().warning("Skipping PlaceholderAPI unregister due to late shutdown state: " + throwable.getMessage());
+            } finally {
+                placeholderAPI = null;
+            }
         }
 
         if (playerNPC != null) {

--- a/src/main/java/dev/cwhead/GravesX/listener/BlockEntityExplodeListener.java
+++ b/src/main/java/dev/cwhead/GravesX/listener/BlockEntityExplodeListener.java
@@ -110,14 +110,10 @@ public class BlockEntityExplodeListener implements Listener {
             Location graveHeadLocation = grave.getLocationDeath();
 
             // If the exploding block is exactly the grave head block, protect it.
-            if (graveHeadLocation != null && graveHeadLocation.equals(block.getLocation())) {
+            if (graveHeadLocation != null && graveHeadLocation.equals(block.getLocation()) && !shouldExplode(grave)) {
                 plugin.debugMessage("[Explode Debug] " + source + ": protecting grave head block for grave "
                         + grave.getUUID(), 2);
                 iterator.remove();
-                continue;
-            }
-
-            if (!shouldExplode(grave)) {
                 continue;
             }
 

--- a/src/main/java/dev/cwhead/GravesX/manager/SafeLocationManager.java
+++ b/src/main/java/dev/cwhead/GravesX/manager/SafeLocationManager.java
@@ -199,6 +199,9 @@ public final class SafeLocationManager {
         entity.getWorld();
         if (!location.getWorld().equals(entity.getWorld())) return null;
 
+        Block feet = location.getBlock();
+        if (MaterialUtil.isWater(feet.getType()) || MaterialUtil.isLava(feet.getType())) return null;
+
         Block below = location.getBlock().getRelative(BlockFace.DOWN);
         if (!below.getType().isSolid()) return null;
 

--- a/src/main/java/dev/cwhead/GravesX/manager/SafeLocationManager.java
+++ b/src/main/java/dev/cwhead/GravesX/manager/SafeLocationManager.java
@@ -402,35 +402,64 @@ public final class SafeLocationManager {
         boolean inWaterOrAbove = MaterialUtil.isWater(originType) || directlyAboveWater;
         boolean inLavaOrAbove = MaterialUtil.isLava(originType) || directlyAboveLava;
 
-        if (directlyAboveWater) {
-            Location above = centerOnBlock(origin);
-            if (above != null && !isVoid(above) && isInsideBorder(above) && !hasGrave(above) && isLocationSafeGraveAboveFluid(above, true)) {
-                candidates.add(new Candidate(above, GravePlacementReason.WATER_ABOVE));
-            }
-        }
-
-        if (directlyAboveLava) {
-            Location above = centerOnBlock(origin);
-            if (above != null && !isVoid(above) && isInsideBorder(above) && !hasGrave(above) && isLocationSafeGraveAboveFluid(above, false)) {
-                candidates.add(new Candidate(above, GravePlacementReason.LAVA_ABOVE));
-            }
-        }
-
         if (inWaterOrAbove) {
+            // SMART-FIRST: prefer the player's last known solid location when available.
+            Location smart = resolveSmartFromLastSolid(livingEntity, origin, grave, useGround, useRoof);
+            if (smart != null) {
+                plugin.debugMessage(prefix + "CHOSEN=" + GravePlacementReason.WATER_SMART + " loc=" + fmtLoc(smart) + " distSq=" + distSq(origin, smart) + ".", 1);
+                return GravePlacementResult.of(smart, GravePlacementReason.WATER_SMART);
+            }
+
+            if (directlyAboveWater) {
+                Location above = centerOnBlock(origin);
+                if (above != null && !isVoid(above) && isInsideBorder(above) && !hasGrave(above) && isLocationSafeGraveAboveFluid(above, true)) {
+                    plugin.debugMessage(prefix + "CHOSEN=" + GravePlacementReason.WATER_ABOVE + " loc=" + fmtLoc(above) + " distSq=" + distSq(origin, above) + ".", 1);
+                    return GravePlacementResult.of(above, GravePlacementReason.WATER_ABOVE);
+                }
+            }
+
             boolean waterTop = plugin.getConfigManager().getConfigSection("placement.water-top", grave).getBoolean("placement.water-top");
 
             if (waterTop) {
                 Location start = MaterialUtil.isWater(originType) ? origin : origin.clone().add(0.0, -1.0, 0.0);
                 Location surface = resolveFluidSurfaceTop(start, grave, true);
                 if (surface != null) {
-                    candidates.add(new Candidate(surface, GravePlacementReason.WATER_TOP));
+                    plugin.debugMessage(prefix + "CHOSEN=" + GravePlacementReason.WATER_TOP + " loc=" + fmtLoc(surface) + " distSq=" + distSq(origin, surface) + ".", 1);
+                    return GravePlacementResult.of(surface, GravePlacementReason.WATER_TOP);
                 } else {
                     plugin.debugMessage(prefix + "water-top enabled but no AIR surface found; continuing.", 1);
                 }
             }
 
-            addWaterCandidates(candidates, origin, livingEntity, grave, useGround, useRoof);
+            boolean waterBottom = plugin.getConfigManager().getConfigSection("placement.water-bottom", grave).contains("placement.water-bottom")
+                    ? plugin.getConfigManager().getConfigSection("placement.water-bottom", grave).getBoolean("placement.water-bottom")
+                    : useGround;
+
+            if (waterBottom) {
+                Location bottom = findWaterBottom(origin);
+                if (bottom != null && !hasGrave(bottom) && isLocationSafeGrave(bottom)) {
+                    plugin.debugMessage(prefix + "CHOSEN=" + GravePlacementReason.WATER_BOTTOM + " loc=" + fmtLoc(bottom) + " distSq=" + distSq(origin, bottom) + ".", 1);
+                    return GravePlacementResult.of(bottom, GravePlacementReason.WATER_BOTTOM);
+                }
+            }
+
+            if (useRoof) {
+                Location roof = resolveRoofLocation(origin, origin, grave);
+                if (roof != null) candidates.add(new Candidate(roof, GravePlacementReason.ROOF));
+            }
+
+            if (useGround) {
+                Location ground = resolveGroundLocation(origin, origin, grave);
+                if (ground != null) candidates.add(new Candidate(ground, GravePlacementReason.GROUND));
+            }
         } else if (inLavaOrAbove) {
+            // SMART-FIRST: prefer the player's last known solid location when available.
+            Location smart = resolveSmartFromLastSolid(livingEntity, origin, grave, useGround, useRoof);
+            if (smart != null) {
+                plugin.debugMessage(prefix + "CHOSEN=" + GravePlacementReason.LAVA_SMART + " loc=" + fmtLoc(smart) + " distSq=" + distSq(origin, smart) + ".", 1);
+                return GravePlacementResult.of(smart, GravePlacementReason.LAVA_SMART);
+            }
+
             boolean lavaTop = plugin.getConfigManager().getConfigSection("placement.lava-top", grave).getBoolean("placement.lava-top");
 
             if (lavaTop) {
@@ -452,7 +481,15 @@ public final class SafeLocationManager {
                 plugin.debugMessage(prefix + "lava-top enabled but no AIR surface found; continuing.", 1);
             }
 
-            addLavaCandidates(candidates, origin, livingEntity, grave, useGround, useRoof);
+            if (useRoof) {
+                Location roof = resolveRoofLocation(origin, origin, grave);
+                if (roof != null) candidates.add(new Candidate(roof, GravePlacementReason.ROOF));
+            }
+
+            if (useGround) {
+                Location ground = resolveGroundLocation(origin, origin, grave);
+                if (ground != null) candidates.add(new Candidate(ground, GravePlacementReason.GROUND));
+            }
         } else {
             if (useRoof) {
                 Location roof = resolveRoofLocation(origin, origin, grave);

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -242,6 +242,14 @@ settings:
       # Should Vault integration be enabled.
       enabled: true
 
+    #############
+    # BagOfGold #
+    #############
+    # Global switch for BagOfGold physical-money split integration.
+    # Detailed split behavior/percentages are configured in grave.yml -> physical-money.bagofgold.
+    bagofgold:
+      enabled: true
+
     ###############
     # ProtocolLib #
     ###############

--- a/src/main/resources/config/grave.yml
+++ b/src/main/resources/config/grave.yml
@@ -266,6 +266,24 @@ settings:
         store-in-grave: true
         store: 0.7
 
+      ##################
+      # Physical Money #
+      ##################
+      # Splits physical BagOfGold money items between grave storage and ground drops.
+      # This only handles item stacks (no digital balance/Vault changes).
+      physical-money:
+        bagofgold:
+          # Enable BagOfGold physical-money split when players die.
+          enabled: true
+          # Scope options: pvp_and_pve, pvp_only, pve_only
+          apply-on: "pvp_and_pve"
+          # Percent of physical money value to keep inside the grave.
+          keep-in-grave-percent: 70
+          # Percent of physical money value to drop outside the grave.
+          drop-on-ground-percent: 30
+          # If split cannot drop anything due to stack granularity, force 1 unit to drop.
+          force-minimum-drop-item: true
+
       ###########
       # Respawn #
       ###########


### PR DESCRIPTION
## Summary
This PR adds a direct BagOfGold physical-money integration and hardens a few runtime paths around grave placement, shutdown, and MariaDB startup behavior.

It is intended to be applied on top of current `fork` (latest upstream commit checked: `a810b47`, Mar 27, 2026).

## What’s included

- Add direct BagOfGold physical-money integration (item-based only, no Vault/digital balance changes).
- Add configurable split of physical money on death:
  - keep part in grave
  - drop part on ground (stealable)
- Add global integration toggle in `config.yml`:
  - `settings.integration.bagofgold.enabled`
- Add detailed split settings in `grave.yml`:
  - `settings.grave.inventory.physical-money.bagofgold.*`

- Improve safe location behavior:
  - prioritize smart placement (`last solid`) for lava/water cases
  - prevent storing invalid “last solid” locations while player is in fluid
  - improve water/lava fallback ordering

- Fix BagOfGold auto-loot balance desync:
  - after GravesX auto-loot moves inventory items, call BagOfGold reconciliation once so balance stays consistent.

- Harden shutdown/unload flow:
  - prevent duplicate shutdown tasks
  - guard late PlaceholderAPI unregister during shutdown.

- Fix MariaDB startup warning:
  - avoid repeatedly altering `grave.uuid` with `UNIQUE` on every startup, which could lead to excessive key creation in some MariaDB setups (`Too many keys specified`).

- Minor startup race hardening:
  - run hologram backend backfill slightly delayed and only when column exists.

## Files touched (high level)

- `src/main/java/com/ranull/graves/integration/BagOfGoldPhysicalMoneyIntegration.java` (new)
- `src/main/java/com/ranull/graves/listener/EntityDeathListener.java`
- `src/main/java/com/ranull/graves/listener/PlayerMoveListener.java`
- `src/main/java/dev/cwhead/GravesX/manager/SafeLocationManager.java`
- `src/main/java/com/ranull/graves/manager/GraveManager.java`
- `src/main/java/com/ranull/graves/manager/IntegrationManager.java`
- `src/main/java/com/ranull/graves/manager/DataManager.java`
- `src/main/java/com/ranull/graves/Graves.java`
- `src/main/resources/config/config.yml`
- `src/main/resources/config/grave.yml`

## Behavior/compatibility notes

- No API break intended.
- BagOfGold integration is config-gated and item-focused.
- No digital/Vault balance transfer logic was added in this PR.
- Existing servers can keep integration disabled if they do not use BagOfGold.

## Validation

Tested in a Paper 1.21.11 smoke environment with:
- GravesX + BagOfGold + CustomItemsLib + Citizens stack
- death/loot flows (including auto-loot)
- startup/shutdown checks

Observed:
- no more MariaDB `1069 Too many keys specified` warning on startup
- stable shutdown
- expected split behavior for physical money items
