### PR TITLE
Fix Curse of Binding Isue

### DIFF
--- a/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
+++ b/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
@@ -506,13 +506,6 @@ public class EntityDeathListener implements Listener {
                         continue;
                     }
 
-                    // ---- Curse of Binding: stays equipped, never stored in grave ----
-                    if (plugin.getVersionManager().hasEnchantmentCurse()
-                            && invItem.containsEnchantment(Enchantment.BINDING_CURSE)) {
-                        it.set(null);
-                        continue;
-                    }
-
                     // ---- Curse of Vanishing: not stored in grave ----
                     if (plugin.getVersionManager().hasEnchantmentCurse()
                             && invItem.containsEnchantment(Enchantment.VANISHING_CURSE)) {


### PR DESCRIPTION
remove Curse of Binding line, items don't stay on players after death, they are instead dropped in vanilla minecraft

the removed section caused the plugin to delete curse of binding items, instead of dropping them (as per default config) or keeping them in the grave

fixes issue #209 