### PR TITLE
Make no-graves command messages configurable in grave.yml

### DIFF
--- a/src/main/java/com/ranull/graves/command/GravesCommand.java
+++ b/src/main/java/com/ranull/graves/command/GravesCommand.java
@@ -582,8 +582,8 @@ public class GravesCommand implements CommandExecutor, TabCompleter {
                     if (!plugin.getGraveManager().getGraveList(otherPlayer).isEmpty()) {
                         plugin.getGUIManager().openGraveList(player, otherPlayer.getUniqueId());
                     } else {
-                        commandSender.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » "
-                                + ChatColor.RESET + ChatColor.RED + args[1] + ChatColor.RESET + " has no graves.");
+                        plugin.getEntityManager().sendMessage("message.no-graves-other", player, args[1],
+                                player.getLocation(), plugin.getConfigManager().getPermissionList(player));
                     }
                 } else {
                     plugin.getEntityManager().sendMessage("message.permission-denied", player);
@@ -635,16 +635,14 @@ public class GravesCommand implements CommandExecutor, TabCompleter {
             var graves = plugin.getGraveManager().getGraveList(player);
 
             if (graves == null || graves.isEmpty()) {
-                player.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » "
-                        + ChatColor.RESET + "You have no graves.");
+                plugin.getEntityManager().sendMessage("message.no-graves", player);
                 return;
             }
 
             Grave grave = graves.get(0);
 
             if (grave == null) {
-                player.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » "
-                        + ChatColor.RESET + "You have no graves.");
+                plugin.getEntityManager().sendMessage("message.no-graves", player);
                 return;
             }
 
@@ -669,16 +667,16 @@ public class GravesCommand implements CommandExecutor, TabCompleter {
             var graves = plugin.getGraveManager().getGraveList(targetPl);
 
             if (graves == null || graves.isEmpty()) {
-                player.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » "
-                        + ChatColor.RESET + ChatColor.RED + args[1] + ChatColor.RESET + " has no graves.");
+                plugin.getEntityManager().sendMessage("message.no-graves-other", player, args[1],
+                        player.getLocation(), plugin.getConfigManager().getPermissionList(player));
                 return;
             }
 
             Grave grave = graves.get(0);
 
             if (grave == null) {
-                player.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » "
-                        + ChatColor.RESET + ChatColor.RED + args[1] + ChatColor.RESET + " has no graves.");
+                plugin.getEntityManager().sendMessage("message.no-graves-other", player, args[1],
+                        player.getLocation(), plugin.getConfigManager().getPermissionList(player));
                 return;
             }
 
@@ -710,7 +708,7 @@ public class GravesCommand implements CommandExecutor, TabCompleter {
 
             var graves = plugin.getGraveManager().getGraveList(player);
             if (graves.isEmpty()) {
-                player.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » " + ChatColor.RESET + "You have no graves.");
+                plugin.getEntityManager().sendMessage("message.no-graves", player);
                 return;
             }
 
@@ -745,8 +743,8 @@ public class GravesCommand implements CommandExecutor, TabCompleter {
             OfflinePlayer targetPl = plugin.getServer().getOfflinePlayer(args[1]);
             var graves = plugin.getGraveManager().getGraveList(targetPl);
             if (graves.isEmpty()) {
-                player.sendMessage(ChatColor.RED + "☠" + ChatColor.DARK_GRAY + " » " + ChatColor.RESET
-                        + ChatColor.RED + args[1] + ChatColor.RESET + " has no graves.");
+                plugin.getEntityManager().sendMessage("message.no-graves-other", player, args[1],
+                        player.getLocation(), plugin.getConfigManager().getPermissionList(player));
                 return;
             }
 

--- a/src/main/java/dev/cwhead/GravesX/manager/ConfigManager.java
+++ b/src/main/java/dev/cwhead/GravesX/manager/ConfigManager.java
@@ -37,7 +37,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public final class ConfigManager {
 
-    public static final int CURRENT_CONFIG_VERSION = 25;
+    public static final int CURRENT_CONFIG_VERSION = 26;
 
     private final Graves plugin;
     private final Paths paths;

--- a/src/main/resources/config/grave.yml
+++ b/src/main/resources/config/grave.yml
@@ -1020,6 +1020,8 @@ settings:
         looted: "You looted &c%owner_name%&r's grave at &c%x%&rx, &c%y%&ry, &c%z%&rz in &c%world_formatted%&r."
         experience: "Looted &c%level% &rlevels from grave."
         empty: "You don't have any graves."
+        no-graves: "You have no graves."
+        no-graves-other: "&c%name%&r has no graves."
         death: "You were killed in &c%world_formatted% &rby &c%killer_name%&r."
         block: "Grave created at &c%x%&rx, &c%y%&ry, &c%z%&rz in &c%world_formatted%&r."
         timeout: "Your grave at &c%x%&rx, &c%y%&ry, &c%z%&rz in &c%world_formatted%&r timed out with &c%item% &ritems and &c%experience% &rExperience."


### PR DESCRIPTION
## Summary

This PR moves the hardcoded "no graves" command responses into the configurable message system under `settings.default.default.message` in `grave.yml`, so server owners can translate and restyle them like every other message the plugin sends.

Right now `GravesCommand` writes these strings inline with `ChatColor`, which bypasses `message.prefix`, ignores per-permission overrides, and leaves no way to localize them.

## Motivation

Server owners already translate the `message:` section (for example `empty: "You don't have any graves."`). The command responses below stay hardcoded in English, so a translated server still shows English text in a different prefix style. This change makes them behave consistently with the rest of the message system.

## Changes

### New message keys (`grave.yml` → `settings.default.default.message`)

```yaml
no-graves: "You have no graves."
no-graves-other: "&c%name%&r has no graves."
```

`%name%` resolves to the target player's name via the existing `EntityManager.sendMessage(String, Entity, String name, Location, List<String>)` overload.

### `GravesCommand.java`

**Self — "You have no graves."** (virtual + teleport paths):
```java
plugin.getEntityManager().sendMessage("message.no-graves", player);
```

**Other player — "\<name\> has no graves."** (GUI + virtual + teleport paths):
```java
plugin.getEntityManager().sendMessage("message.no-graves-other", player, args[1],
        player.getLocation(), plugin.getConfigManager().getPermissionList(player));
```

### `ConfigManager.java`

Bump `CURRENT_CONFIG_VERSION` so `ConfigUpdater` merges the new keys into existing server configs on upgrade. `ConfigUpdater` preserves admin edits and only adds missing keys.

## Behavior notes

- Each message now uses the configured `message.prefix` instead of the inline `☠ »` format, matching every other plugin message.
- Setting a key to an empty string disables that message (the existing early-return convention in `EntityManager.sendMessage`).

## Out of scope

This PR intentionally leaves the admin purge responses hardcoded — "No graves found for offline player ..." and "No graves found for UUID ...". Those commands respond to a `CommandSender` that can be the console, whereas `EntityManager.sendMessage` only delivers to a `Player`. Routing them through the message system would silently drop console output and break consistency with the surrounding admin feedback, so they deserve a separate change if desired.

## Test plan

- [ ] `/graves teleport` and `/graves virtual` with no graves → shows `no-graves`
- [ ] `/graves teleport <player>` / `/graves virtual <player>` / GUI-other for a player with no graves → shows `no-graves-other` with correct name
- [ ] Set `no-graves` to `""` → no message sends
- [ ] Upgrade from a prior config → new keys appear, existing custom messages remain untouched